### PR TITLE
Escaping eingebaut, da es sonst Probleme mit dem aktuellen Sendungstitel...

### DIFF
--- a/source/_includes/post/flattr.html
+++ b/source/_includes/post/flattr.html
@@ -2,7 +2,7 @@
   <a class="FlattrButton" style="display:none;"
     {% capture title %}{{ post.title }}{{ page.title }}{% endcapture %}
     {% capture url %}{{ post.url }}{{ page.url }}{% endcapture %}
-    title="{{ title }}"
+    title="{{ title | xml_escape }}"
     data-flattr-uid="{{ site.flattr_uid }}"
     data-flattr-tags="{{ site.flattr_tags }}"
     data-flattr-button="compact"


### PR DESCRIPTION
... gibt. (Binärgewitter Talk #11 - Btrfs -> cheeseFS). Der Flattr-Button ist deswegen kaputt.

Ich hab ja eigentlich keinen Plan von Ruby... hoffe das ist richtig so. Vielleicht gibt es noch mehr Stellen wo man das Escaping einbauen sollte.
