### PR TITLE
Update 2013-07-12-binaergewitter-talk-number-58-schoepfungshoehe-nicht-e...

### DIFF
--- a/source/_posts/2013-07-12-binaergewitter-talk-number-58-schoepfungshoehe-nicht-erreicht.markdown
+++ b/source/_posts/2013-07-12-binaergewitter-talk-number-58-schoepfungshoehe-nicht-erreicht.markdown
@@ -13,62 +13,192 @@ audioformats:
 ---
 Mit Pfleidi, Felix und Ingo und auch gar nicht so lang aber wieder dumm, unlustig und geschmacklos.
 
-## Toter der Woche
+##Intro ```00:00:00```  
+* [Begrüßung zur 58ten Episode des Binärgewitter Podcast](http://blog.binaergewitter.de/)  
+* [Begrüßung der NSA](http://de.wikipedia.org/wiki/National_Security_Agency)  
+* Shownotes Crowdsourcen  
+* [Shownot.es Projekt](http://shownot.es/)  
+* [Simon Waldherr](https://alpha.app.net/simonwaldherr)  
+* „We want you for Shownotes“  
+* „Die Bundeswehr Marine holt die Bananen“  
 
-* [Google Latitude](http://www.heise.de/newsticker/meldung/Runderneuerung-fuer-Google-Maps-Aus-fuer-Latitude-1915196.html )
-* [Seth Vidal](http://www.heise.de/newsticker/meldung/Fedora-und-Yum-Entwickler-Seth-Vidal-bei-Fahrradunfall-getoetet-1914614.html )
+##Toter der Woche ```00:02:46```  
 
-# Untoter der Woche
+###[Google Latitude](https://www.google.de/latitude/b/0) ```00:02:52```  
+* [Geofencing](http://de.wikipedia.org/wiki/Geofencing)  
+* Es ist schon interessant zu wissen wo sich jemand befindet  
+* [PRISM](http://de.wikipedia.org/wiki/PRISM_%28%C3%9Cberwachungsprogramm%29)  
+* [NSA](http://de.wikipedia.org/wiki/National_Security_Agency)  
+* „Kranke Technologien aus den Neunzigern“  
+    * [SOAP](http://de.wikipedia.org/wiki/SOAP)
+    * [CORBA](http://en.wikipedia.org/wiki/CORBA)
+    * [IPX](http://en.wikipedia.org/wiki/Internetwork_Packet_Exchange)
+* Starcraft  
+* [Command and Conquer](http://en.wikipedia.org/wiki/Command_and_Conquer)  
+* Am 9 (Monat einfügen) ist Schluss mit Google Latitude  
+* Als Ersatz soll Google+ dienen  
+* [Cronjob](http://de.wikipedia.org/wiki/Cronjob)  
+* [Moves](http://www.moves-app.com/)  
+* [KML](http://de.wikipedia.org/wiki/Keyhole_Markup_Language)  
+* Google hat einem wenigstens die Daten gegeben  
+* [Endomondo](http://www.endomondo.com/)  
+* [Open Street Map](http://www.openstreetmap.org/)  
+* [My Tracks](http://www.google.com/mobile/mytracks/)  
+* [Fitbit](http://www.fitbit.com/de)  
 
-- [Openleaks]( http://www.heise.de/newsticker/meldung/Daniel-Domscheit-Berg-Openleaks-lebt-noch-1909846.html )
-   * [Endlich duerft ihr mit Mastercard Julien Assange supporten ]( http://wikileaks.org/MasterCard-breaks-ranks-in.html )
-- [Tizen]( http://www.tizenexperts.com/2013/07/is-tizen-really-dead-well-intel-doesnt-think-so/ )
+###[Seth Vidal](https://lists.fedoraproject.org/pipermail/announce/2013-July/003174.html) ```00:11:41```  
+* [Yum](http://fedoraproject.org/wiki/Yum)  
+    * [yellowdog updater modified](http://yum.baseurl.org/)
+* [Yellow Dog Linux](http://en.wikipedia.org/wiki/Yellow_Dog_Linux)  
+* [Power PC](http://de.wikipedia.org/wiki/Power_PC)  
+* Sony Playstation 3 mit Linux  
+* [IBM Power Linux](http://www-03.ibm.com/systems/power/software/linux/)  
+* [Fedora](http://fedoraproject.org/)  
+* [Arch Linux](https://www.archlinux.org/)  
+* [SuSe Linux](https://www.suse.com)  
+* [Red Hat Enterprise Linux](http://www.redhat.com/products/enterprise-linux/)  
+* [Symlink](http://de.wikipedia.org/wiki/Symbolische_Verkn%C3%BCpfung)  
+* [Linux Verzeichnisstruktur](http://de.wikipedia.org/wiki/Filesystem_Hierarchy_Standard)  
+* [Manjaro](http://manjaro.org/)  
+* [Python](http://de.wikipedia.org/wiki/Python_%28Programmiersprache%29)  
 
-## News
+##Untoter der Woche ```00:17:00```  
 
-- [Valve Software hat men Github Account]( https://github.com/ValveSoftware )
-- [1200 exploitable crashes in Debian (in 22000 Projekten)]( http://lists.debian.org/debian-devel/2013/06/msg00720.html )
-- [Kein Urheberrechtsschutz für pr0n]( http://www.heise.de/newsticker/meldung/Urteil-Kein-Urheberrechtsschutz-fuer-Pornos-1908794.html )
-- [NSA baut kostenloses Cloud-Basiertes Backup](  )
-- [Sähroboter](http://www.heise.de/newsticker/meldung/Saehroboter-fuer-den-englischen-Rasen-1916047.html )
-- [Sky will Werbung in die Brains projezieren]( 
-http://www.telegraph.co.uk/finance/newsbysector/mediatechnologyandtelecoms/media/10158311/Sky-Deutschland-to-broadcast-adverts-directly-into-train-passengers-heads.html )
-- [Github bring Release-Management]( https://github.com/blog/1547-release-your-software )
-- [Untertitelseite offline wegen Razia](http://www.heise.de/newsticker/meldung/Schwedische-Polizei-beschlagnahmt-Server-von-Untertitel-Webseite-1915924.html )
-- [Oracle ändert Lizenz von BerkeleyDB zu AGPL]( http://developers.slashdot.org/story/13/07/05/1647215/oracle-quietly-switches-berkeleydb-to-agpl )
-- [Endlich saubere Energie!]( http://www.extremetech.com/extreme/160131-thorium-nuclear-reactor-trial-begins-could-provide-cleaner-safer-almost-waste-free-energy )
-- [Firefox Phone in Dtl.](http://www.heise.de/newsticker/meldung/Congstar-Firefox-Smartphone-ab-Herbst-in-Deutschland-1916056.html )
-- [Chrome 28 kommt mit Blink]( http://thenextweb.com/google/2013/07/09/chrome-28-arrives-with-rich-notifications-for-apps-and-extensions-on-windows-mac-and-linux-coming-soon/ )
-- [3D-Kopierer vom Discounter]( http://www.heise.de/hardware-hacks/meldung/3D-Kopierer-vom-Discounter-1913328.html )
-    * [Yo dawg I herd you like chicken nuggets]( http://memegenerator.co/instance/39618442 )
-- [FFmpeg mit opencl](http://www.heise.de/newsticker/meldung/FFmpeg-2-0-unterstuetzt-OpenCL-1914416.html )
-- [Der Sarkasmusdetektor, funktioniert bestimmt]( http://tech.slashdot.org/story/13/07/05/2034253/tech-companies-looking-into-sarcasm-detection )
+###[Open Leaks](http://de.wikipedia.org/wiki/OpenLeaks) ```00:17:05```  
+* [Daniel Domscheit Berg (der einzige hinter OpenLeaks)](http://de.wikipedia.org/wiki/Daniel_Domscheit-Berg)  
+* Endlich duerft ihr mit Mastercard Julien Assange supporten  
 
-## Lesefoo
+###[Tizen](https://www.tizen.org/) ```00:17:57```  
+* [Intel (+Samsung) App Challenge (4 Millonen $)](http://www.eweek.com/mobile/intel-samsung-kick-off-app-contest-for-tizen-os/)  
+* iOS Apps sind in Objectiv-C, Android Apps in Java  
+    * [Objectiv C](http://de.wikipedia.org/wiki/Objective_C)
+    * [Java](http://de.wikipedia.org/wiki/Java_%28Programmiersprache%29)
+* Die Challenge wird viele halbfertige Apps hervorbringen  
+* „Mit Tizen Geld verdienen funktioniert auf jedem Fall“  
 
-- [APIGeee Web API Design Ebook]( http://pages.apigee.com/web-api-design-ebook.html )
-    * [Richardson maturity model]( http://martinfowler.com/articles/richardsonMaturityModel.html )
-    - [HTTP 2.0](http://en.wikipedia.org/wiki/HTTP_2.0 )
-- [Benchmarking  Ruby Code]( http://rubylearning.com/blog/2013/06/19/how-do-i-benchmark-ruby-code/ )
-- [A Statistical Analysis of Nerf Blasters and Darts]( http://shawntoneil.com/index.php/pages/nerftest1 )
+##News ```00:20:31```  
 
-## Mimimi der Woche
+###[Valve hat einen Github Account für SDKs](https://github.com/ValveSoftware) ```00:20:40```  
+* und als Issue Tracker  
+* [ID Software](http://de.wikipedia.org/wiki/ID_Software)  
+* [Debian Crash Report Sammlung der Carnegie Mellon University](http://lists.debian.org/debian-devel/2013/06/msg00720.html)  
+* 1200 exploitable crashes in Debian (in 22000 Projekten)  
+* [Carnegie Mellon University](http://www.cmu.edu/index.shtml)  
 
-- [Shownot.es Nutzung in Podcasts]( http://shownot.es/ ) (pfleidi)
-    * [OSF in a nutshell]( https://github.com/shownotes/OSF-in-a-Nutshell )
-    * [Shownotes Format]( https://github.com/shownotes/OpenShownotesFormat )
-    * [Binärgewitter Show-Pad]( http://pad.shownot.es/doc/binaergewitter-58 )
+###[Kein Urheberrechtsschutz für pr0n](http://www.heise.de/newsticker/meldung/Urteil-Kein-Urheberrechtsschutz-fuer-Pornos-1908794.html) ```00:27:20```  
+* [Urheberrecht](http://de.wikipedia.org/wiki/Urheberrechtsschutz)  
+* „Warum hast du eigentlich ne Maske auf?“  
+* „Keine Schöpfungshöhe“  
+* [Marketingfail bei der NSA, NSA baut kostenloses Cloud-basiertes Backup](http://prism.andrevv.com/)  
 
-## Picks
+###[Sähroboter](http://www.heise.de/newsticker/meldung/Saehroboter-fuer-den-englischen-Rasen-1916047.html) ```00:31:30```  
+* [Arduino](http://arduino.cc/)  
+* [Monsanto](http://de.wikipedia.org/wiki/Monsanto)  
+* [Nummer 5 lebt](http://www.imdb.com/title/tt0091949/)  
+* [Wall-E](http://www.imdb.com/title/tt0910970/)  
+* [Instructables](http://www.instructables.com/)  
 
-- [Bundeswehr beschützt die Bananen]( https://www.youtube.com/watch?v=86ELBWLNdmg )
-- Bitcoin Miner gewinnen
-- [Gesundheit!]( https://itunes.apple.com/de/app/gesundheit!/id591696651?l=en&mt=8 )
-- [Regex Visualisieren]( http://www.debuggex.com/ )
-  - [Regex Tester]( http://regexpal.com/ )
-- [Badland]( https://itunes.apple.com/de/app/badland/id535176909?l=en&mt=8 )
-- [Where ist my Water?](https://itunes.apple.com/de/app/wheres-my-water/id449735650?mt=8 )
-- [Seeks - Decentralized Search and Filtering]( http://www.seeks-project.info/site/ )
-- [ixquick](https://www.ixquick.com/
+###[Sky will Werbung in die Brains projizieren](http://www.telegraph.co.uk/finance/newsbysector/mediatechnologyandtelecoms/media/10158311/Sky-Deutschland-to-broadcast-adverts-directly-into-train-passengers-heads.html) ```00:34:29```  
+* [Subliminale Botschaften](http://de.wikipedia.org/wiki/Subliminal_%28Psychologie%29)  
+* [Github bring Release-Management](https://github.com/blog/1547-release-your-software)  
+
+###[Untertitelseite offline wegen Razia](http://www.heise.de/newsticker/meldung/Schwedische-Polizei-beschlagnahmt-Server-von-Untertitel-Webseite-1915924.html) ```00:39:31```  
+* [Piratebay](http://thepiratebay.se)  
+* [Flattr](http://flattr.com)  
+* [Undertexter](http://www.undertexter.se/)  
+* „Unsere Shownotes Schreiber sind toll“  
+
+###[Oracle ändert Lizenz von BerkeleyDB zu AGPL](http://developers.slashdot.org/story/13/07/05/1647215/oracle-quietly-switches-berkeleydb-to-agpl) ```00:42:45```  
+* [BerkeleyDB](http://de.wikipedia.org/wiki/Berkeley_DB)  
+* [AGPL](http://de.wikipedia.org/wiki/GNU_Affero_General_Public_License)  
+* „Die Assi GPL wegforken“  
+* [MySQL](https://de.wikipedia.org/wiki/MySQL)  
+* „Oracle hat keine Lust mehr, dass man ihre Software noch verwendet“  
+* [Sleepycat Software](http://de.wikipedia.org/wiki/Sleepycat_Software)  
+
+###[Endlich saubere Energie!](http://www.extremetech.com/extreme/160131-thorium-nuclear-reactor-trial-begins-could-provide-cleaner-safer-almost-waste-free-energy) ```00:45:27```  
+* [Thorium](http://de.wikipedia.org/wiki/Thorium)  
+* [Fukushima Daiichi](http://de.wikipedia.org/wiki/Kernkraftwerk_Fukushima_Daiichi)  
+* [Tagesschau Meldung zu Fukushima](http://www.tagesschau.de/ausland/japan-atomkraft104.html)  
+* [Ex-Manager von Fukushima an Krebs gestorben](http://www.tagesspiegel.de/weltspiegel/japan-ex-manager-von-fukushima-an-krebs-gestorben/8476138.html)  
+
+###[Firefox Phone in Deutschland](http://www.heise.de/newsticker/meldung/Congstar-Firefox-Smartphone-ab-Herbst-in-Deutschland-1916056.html) ```00:48:00```  
+* [Alcatel one touch](http://www.alcatelonetouch.com/de/)  
+
+###[Chrome 28 kommt mit Blink](http://thenextweb.com/google/2013/07/09/chrome-28-arrives-with-rich-notifications-for-apps-and-extensions-on-windows-mac-and-linux-coming-soon/) ```00:49:58```  
+* [Blink: A rendering engine for Chrome](http://blog.chromium.org/2013/04/blink-rendering-engine-for-chromium.html)  
+* [Chromium](http://www.chromium.org/)  
+
+###[3D-Kopierer/Drucker vom Discounter](http://www.heise.de/hardware-hacks/meldung/3D-Kopierer-vom-Discounter-1913328.html) ```00:51:35```  
+* [Pearl](http://www.pearl.de)  
+* [Makerbot](http://www.makerbot.com/)  
+* „Käse mit oder ohne Löcher drucken“  
+* [Yo dawg I herd you like chicken nuggets](http://memegenerator.co/instance/39618442)  
+* [Molekulares kochen](http://de.wikipedia.org/wiki/Molekulark%C3%BCche)  
+
+###[FFmpeg mit OpenCL](http://www.heise.de/newsticker/meldung/FFmpeg-2-0-unterstuetzt-OpenCL-1914416.html) ```00:56:21```  
+* [Handbrake](http://handbrake.fr/)  
+* [M-JPEG](http://de.wikipedia.org/wiki/Motion_JPEG)  
+* [Der Sarkasmusdetektor, funktioniert bestimmt](http://tech.slashdot.org/story/13/07/05/2034253/tech-companies-looking-into-sarcasm-detection)  
+
+##Lesefoo ```01:02:13```  
+
+###[APIGeee Web API Design Ebook](http://pages.apigee.com/web-api-design-ebook.html) ```01:02:36```  
+* [Suche über Google](https://www.google.de/search?site=&source=hp&q=APIGeee+Web+API+Design+Ebook&oq=APIGeee+Web+API+Design+Ebook)  
+* [Richardson maturity model](http://martinfowler.com/articles/richardsonMaturityModel.html)  
+* [HTTP 2.0](http://en.wikipedia.org/wiki/HTTP_2.0)  
+* [SPDY](http://de.wikipedia.org/wiki/SPDY)  
+* [HTTP/1.1](http://de.wikipedia.org/wiki/HTTP)  
+* [TCP](http://de.wikipedia.org/wiki/Transmission_Control_Protocol)  
+* [Websockets](http://de.wikipedia.org/wiki/WebSocket)  
+* [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)  
+* HTTP 2.0 komprimiert auch die HTTP Header  
+* [IPv6](http://de.wikipedia.org/wiki/IPv6)  
+
+###[Benchmarking  Ruby Code](http://rubylearning.com/blog/2013/06/19/how-do-i-benchmark-ruby-code/) ```01:14:18```  
+* Der Blog Eintrag gibt einen guten Überblick  
+* [Benchmark.bmbm](http://www.ruby-doc.org/stdlib-2.0/libdoc/benchmark/rdoc/Benchmark.html)  
+
+###[A Statistical Analysis of Nerf Blasters and Darts](http://shawntoneil.com/index.php/pages/nerftest1) ```01:15:25```  
+* Sience mit Nerf Guns  
+* [LaTeX](http://de.wikipedia.org/wiki/LaTeX)  
+* [Rule 34](http://knowyourmeme.com/memes/rule-34)  
+
+##Mimimi der Woche ```01:18:12```  
+* [Shownot.es Nutzung in Podcasts (pfleidi)](http://shownot.es/)  
+* [Open Shownotes Format (OSF) - OSF in a nutshell](https://github.com/shownotes/OSF-in-a-Nutshell)  
+* Tools des Shownot.es Teams  
+    * [ShowPad](https://github.com/shownotes/show-pad)
+    * [tinyOSF.js (OSF Parser in JS)](https://github.com/shownotes/tinyOSF.js)
+    * [shownot.es Wordpress Plugin](https://github.com/SimonWaldherr/wp-osf-shownotes)
+    * [(…)](https://github.com/shownotes)
+* Die Shownot.es Tools ermöglichen die Ausgabe in verschiedenen Formaten  
+    * Kapitelmarken (mp4chaps)
+    * HTML (verschiedene Styles)
+    * Markdown
+* [Shownot.es Flattr Page](https://flattr.com/profile/shownotes)  
+* [Binärgewitter Flattr Page](https://flattr.com/profile/binaergewitter)  
+* [Xenim](http://streams.xenim.de/)  
+* „mehr Metadaten ist immer gut“  
+* Das Shownot.es Team teilt hiermit mit, dass die meisten Probleme bereits gefixt sind  
+
+##Picks ```01:30:25```  
+* [Bundeswehr beschützt die Bananen](https://www.youtube.com/watch?v=86ELBWLNdmg)  
+* „Erst gabs Rosinenbomber, jetzt gibts Bananenzerstörer“  
+* [Bitcoin Miner](https://twitter.com/makefoo/status/352050359075737603/photo/1)  
+    * [Butterfly Labs](http://www.butterflylabs.com/)
+* [Gesundheit!](https://itunes.apple.com/de/app/gesundheit!/id591696651?l=en&mt=8)  
+* [Regex Visualisieren](http://www.debuggex.com/)  
+* [Regex Tester](http://regexpal.com/)  
+* [Badland](https://itunes.apple.com/de/app/badland/id535176909?l=en&mt=8)  
+* [Where ist my Water?](https://itunes.apple.com/de/app/wheres-my-water/id449735650?mt=8)  
+* [Seeks - Decentralized Search and Filtering](http://www.seeks-project.info/site/)  
+* [DuckDuckGo](https://duckduckgo.com)  
+* [ixquick](https://www.ixquick.com/)  
+* [MetaGer2](http://metager2.de/)  
+* [PubSubHubbub (PuSH)](http://de.wikipedia.org/wiki/PubSubHubbub)  
+* „LASER!“  
+
+##Ende ```01:47:07```  
 
 


### PR DESCRIPTION
...rreicht.markdown

BGT058 Shownotes from the shownot.es team.
Markdown generated with [tinyOSF](https://github.com/SimonWaldherr/tinyOSF.js). 
Written in the [ShowPad](https://github.com/shownotes/show-pad). The show notes were originally written in the [Open Shownotes Format](http://shownotes.github.io/OSF-in-a-Nutshell/#deutsch).
